### PR TITLE
Add pagination, fast counting for queries, base settings model, proposal reference model

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -32,12 +32,12 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"] # can add windows-latest, macos-latest
-        python: ["3.10", "3.11"]
+        python: ["3.11", "3.12"]
         install: ["-e .[dev]"]
         # Make one version be non-editable to test both paths of version code
         include:
           - os: "ubuntu-latest"
-            python: "3.9"
+            python: "3.10"
             install: ".[dev]"
 
     runs-on: ${{ matrix.os }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
         stages: [commit]
         language: system
         entry: black --check --diff
-        exclude: src/tables.py
+        exclude: src/lims_utils/tables.py
         types: [python]
 
       - id: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,7 @@ repos:
         stages: [commit]
         language: system
         entry: black --check --diff
+        exclude: src/tables.py
         types: [python]
 
       - id: ruff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.2] - 2024-02-14
+## [0.2.0] - 2024-02-14
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2024-02-14
+
+### Added
+
+- `ProposalReference` model and `parse_proposal`, for parsing proposal reference strings
+- `Database()` now exposes `paginate`, for inserting pagination into queries, and `fast_count`, for counting total items rapidly
+- `Settings()`, which provides a base settings model that reads from JSON files
+
+### Changed
+
+- Updated table models
+
 ## [0.1.2] - 2024-02-08
 
 ### Removed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "SQLAlchemy~=2.0.16",
     "fastapi~=0.104.1",
     "pydantic~=2.5.1",
+    "pydantic-settings~=2.1.0"
 ]
 dynamic = ["version"]
 license.file = "LICENSE"

--- a/src/lims_utils/database.py
+++ b/src/lims_utils/database.py
@@ -1,10 +1,15 @@
 import contextlib
-import contextvars
-from typing import Generator
+from contextvars import ContextVar
+from typing import Generator, Optional, Sequence, Tuple, TypeVar
 
+from sqlalchemy import Row, Select, func, literal_column, select
 from sqlalchemy.orm import Session, sessionmaker
 
-_inner_session = contextvars.ContextVar("_inner_session", default=None)
+from .models import Paged
+
+_inner_session: ContextVar[Session | None] = ContextVar("_inner_session", default=None)
+
+T = TypeVar("T")
 
 
 class Database:
@@ -16,7 +21,7 @@ class Database:
         _inner_session.set(session)
 
     @property
-    def session(cls) -> Session:
+    def session(self) -> Session:
         try:
             current_session = _inner_session.get()
             if current_session is None:
@@ -25,14 +30,66 @@ class Database:
         except (AttributeError, LookupError):
             raise Exception("Can't get session. Please call Database.set_session()")
 
+    def fast_count(self, query: Select) -> int:
+        return self.session.execute(
+            query.with_only_columns(func.count(literal_column("1"))).order_by(None)
+        ).scalar_one()
+
+    def paginate(
+        self,
+        query: Select[Tuple[T]],
+        limit: int,
+        page: int,
+        slow_count=True,
+        precounted_total: Optional[int] = None,
+        scalar=True,
+    ):
+        """Paginate a query before querying database
+
+        Args:
+            query: Original query
+            limit: Number of items to return per page
+            page: Page to access
+            slow_count: Count number of total items in a slower, safer manner (useful with GROUP statements)
+            precounted_total: Skip count, use this total instead
+            scalar: Is query already scalar (use `execute` instead of `scalars` when executing)
+
+        Returns
+            Paged representation of query"""
+
+        if precounted_total is not None:
+            total = precounted_total
+        elif slow_count:
+            total = self.session.execute(
+                select(func.count(literal_column("1"))).select_from(query.subquery())
+            ).scalar_one()
+        else:
+            total = self.fast_count(query)
+
+        data: Sequence[Row[Tuple[T]]] | Sequence[T] = []
+
+        if total:
+            if page < 0:
+                page = (total // limit) + page
+
+            new_query = query.limit(limit).offset((page) * limit)
+
+            if scalar:
+                data = self.session.execute(new_query).all()
+            else:
+                data = self.session.scalars(new_query).all()
+
+        return Paged(items=data, total=total, limit=limit, page=page)
+
 
 @contextlib.contextmanager
 def get_session(session_maker: sessionmaker[Session]) -> Generator[Session, None, None]:
     """Database session context manager. Can be used with `Database` and context vars, which is the default
     implementation, but works well on its own as a context manager or dependency.
 
-    :params sessionmaker[:class:`Session`] session_maker: Session maker, returned by SQLAlchemy ORM's `sessionmaker`
-    builder."""
+    Args:
+        session_maker: Session maker, returned by SQLAlchemy ORM's `sessionmaker` builder.
+    """
     inner_db_session = session_maker()
     try:
         Database.set_session(inner_db_session)

--- a/src/lims_utils/settings.py
+++ b/src/lims_utils/settings.py
@@ -1,0 +1,80 @@
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, Literal, Tuple, Type
+
+from pydantic import BaseModel
+from pydantic.fields import FieldInfo
+from pydantic_settings import (
+    BaseSettings,
+    PydanticBaseSettingsSource,
+    SettingsConfigDict,
+)
+
+
+class Auth(BaseModel):
+    endpoint: str = "https://localhost/auth"
+    type: Literal["dummy", "micro"] = "micro"
+    cookie_key: str = "cookie_key"
+
+
+class DB(BaseModel):
+    pool: int = 3
+    overflow: int = 6
+
+
+class JsonConfigSettingsSource(PydanticBaseSettingsSource):
+    """Reads application settings from JSON file"""
+
+    def get_field_value(
+        self, field: FieldInfo, field_name: str
+    ) -> Tuple[Any, str, bool]:
+        encoding = self.config.get("env_file_encoding")
+        file_content_json = json.loads(
+            Path(os.environ.get("CONFIG_PATH") or "config.json").read_text(encoding)
+        )
+        field_value = file_content_json.get(field_name)
+        return field_value, field_name, False
+
+    def prepare_field_value(
+        self, field_name: str, field: FieldInfo, value: Any, value_is_complex: bool
+    ) -> Any:
+        return value
+
+    def __call__(self) -> Dict[str, Any]:
+        d: Dict[str, Any] = {}
+
+        for field_name, field in self.settings_cls.model_fields.items():
+            field_value, field_key, value_is_complex = self.get_field_value(
+                field, field_name
+            )
+            field_value = self.prepare_field_value(
+                field_name, field, field_value, value_is_complex
+            )
+            if field_value is not None:
+                d[field_key] = field_value
+
+        return d
+
+
+class Settings(BaseSettings):
+    """Base settings for application"""
+
+    model_config = SettingsConfigDict(env_file_encoding="utf-8")
+
+    auth: Auth = Auth()
+    db: DB = DB()
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: Type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> Tuple[PydanticBaseSettingsSource, ...]:
+        return (
+            init_settings,
+            JsonConfigSettingsSource(settings_cls),
+        )

--- a/src/lims_utils/tables.py
+++ b/src/lims_utils/tables.py
@@ -199,9 +199,9 @@ class AutoProcProgram(Base):
     MotionCorrection: Mapped[List["MotionCorrection"]] = relationship(
         "MotionCorrection", back_populates="AutoProcProgram_"
     )
-    PDBEntry_has_AutoProcProgram: Mapped[List["PDBEntryHasAutoProcProgram"]] = (
-        relationship("PDBEntryHasAutoProcProgram", back_populates="AutoProcProgram_")
-    )
+    PDBEntry_has_AutoProcProgram: Mapped[
+        List["PDBEntryHasAutoProcProgram"]
+    ] = relationship("PDBEntryHasAutoProcProgram", back_populates="AutoProcProgram_")
     CTF: Mapped[List["CTF"]] = relationship("CTF", back_populates="AutoProcProgram_")
     ParticlePicker: Mapped[List["ParticlePicker"]] = relationship(
         "ParticlePicker", back_populates="AutoProcProgram_"
@@ -209,9 +209,9 @@ class AutoProcProgram(Base):
     RelativeIceThickness: Mapped[List["RelativeIceThickness"]] = relationship(
         "RelativeIceThickness", back_populates="AutoProcProgram_"
     )
-    ParticleClassificationGroup: Mapped[List["ParticleClassificationGroup"]] = (
-        relationship("ParticleClassificationGroup", back_populates="AutoProcProgram_")
-    )
+    ParticleClassificationGroup: Mapped[
+        List["ParticleClassificationGroup"]
+    ] = relationship("ParticleClassificationGroup", back_populates="AutoProcProgram_")
     XRFFluorescenceMapping: Mapped[List["XRFFluorescenceMapping"]] = relationship(
         "XRFFluorescenceMapping", back_populates="AutoProcProgram_"
     )
@@ -392,9 +392,9 @@ class BLSample(Base):
     BLSampleGroup_has_BLSample: Mapped[List["BLSampleGroupHasBLSample"]] = relationship(
         "BLSampleGroupHasBLSample", back_populates="BLSample_"
     )
-    BLSample_has_DataCollectionPlan: Mapped[List["BLSampleHasDataCollectionPlan"]] = (
-        relationship("BLSampleHasDataCollectionPlan", back_populates="BLSample_")
-    )
+    BLSample_has_DataCollectionPlan: Mapped[
+        List["BLSampleHasDataCollectionPlan"]
+    ] = relationship("BLSampleHasDataCollectionPlan", back_populates="BLSample_")
     DataCollectionGroup: Mapped[List["DataCollectionGroup"]] = relationship(
         "DataCollectionGroup", back_populates="BLSample_"
     )
@@ -480,12 +480,12 @@ class BLSampleImage(Base):
     BLSampleImageMeasurement: Mapped[List["BLSampleImageMeasurement"]] = relationship(
         "BLSampleImageMeasurement", back_populates="BLSampleImage_"
     )
-    BLSampleImage_has_Positioner: Mapped[List["BLSampleImageHasPositioner"]] = (
-        relationship("BLSampleImageHasPositioner", back_populates="BLSampleImage_")
-    )
-    BLSampleImage_has_AutoScoreClass: Mapped[List["BLSampleImageHasAutoScoreClass"]] = (
-        relationship("BLSampleImageHasAutoScoreClass", back_populates="BLSampleImage_")
-    )
+    BLSampleImage_has_Positioner: Mapped[
+        List["BLSampleImageHasPositioner"]
+    ] = relationship("BLSampleImageHasPositioner", back_populates="BLSampleImage_")
+    BLSampleImage_has_AutoScoreClass: Mapped[
+        List["BLSampleImageHasAutoScoreClass"]
+    ] = relationship("BLSampleImageHasAutoScoreClass", back_populates="BLSampleImage_")
 
 
 class BLSampleImageAutoScoreSchema(Base):
@@ -504,11 +504,11 @@ class BLSampleImageAutoScoreSchema(Base):
         comment="Whether this schema is enabled (could be configurable in the UI)",
     )
 
-    BLSampleImageAutoScoreClass: Mapped[List["BLSampleImageAutoScoreClass"]] = (
-        relationship(
-            "BLSampleImageAutoScoreClass",
-            back_populates="BLSampleImageAutoScoreSchema_",
-        )
+    BLSampleImageAutoScoreClass: Mapped[
+        List["BLSampleImageAutoScoreClass"]
+    ] = relationship(
+        "BLSampleImageAutoScoreClass",
+        back_populates="BLSampleImageAutoScoreSchema_",
     )
 
 
@@ -789,10 +789,10 @@ class ContainerRegistry(Base):
     ContainerReport: Mapped[List["ContainerReport"]] = relationship(
         "ContainerReport", back_populates="ContainerRegistry_"
     )
-    ContainerRegistry_has_Proposal: Mapped[List["ContainerRegistryHasProposal"]] = (
-        relationship(
-            "ContainerRegistryHasProposal", back_populates="ContainerRegistry_"
-        )
+    ContainerRegistry_has_Proposal: Mapped[
+        List["ContainerRegistryHasProposal"]
+    ] = relationship(
+        "ContainerRegistryHasProposal", back_populates="ContainerRegistry_"
     )
     Container: Mapped[List["Container"]] = relationship(
         "Container", back_populates="ContainerRegistry_"
@@ -1094,9 +1094,9 @@ class DataCollection(Base):
     AutoProcIntegration: Mapped[List["AutoProcIntegration"]] = relationship(
         "AutoProcIntegration", back_populates="DataCollection_"
     )
-    DataCollectionFileAttachment: Mapped[List["DataCollectionFileAttachment"]] = (
-        relationship("DataCollectionFileAttachment", back_populates="DataCollection_")
-    )
+    DataCollectionFileAttachment: Mapped[
+        List["DataCollectionFileAttachment"]
+    ] = relationship("DataCollectionFileAttachment", back_populates="DataCollection_")
     EventChain: Mapped[List["EventChain"]] = relationship(
         "EventChain", back_populates="DataCollection_"
     )
@@ -1202,9 +1202,9 @@ class Detector(Base):
     DiffractionPlan: Mapped[List["DiffractionPlan"]] = relationship(
         "DiffractionPlan", back_populates="Detector_"
     )
-    DataCollectionPlan_has_Detector: Mapped[List["DataCollectionPlanHasDetector"]] = (
-        relationship("DataCollectionPlanHasDetector", back_populates="Detector_")
-    )
+    DataCollectionPlan_has_Detector: Mapped[
+        List["DataCollectionPlanHasDetector"]
+    ] = relationship("DataCollectionPlanHasDetector", back_populates="Detector_")
 
 
 class DewarLocation(Base):
@@ -1690,9 +1690,9 @@ class Positioner(Base):
     positioner: Mapped[str] = mapped_column(String(50))
     value: Mapped[float] = mapped_column(Float)
 
-    BLSampleImage_has_Positioner: Mapped[List["BLSampleImageHasPositioner"]] = (
-        relationship("BLSampleImageHasPositioner", back_populates="Positioner_")
-    )
+    BLSampleImage_has_Positioner: Mapped[
+        List["BLSampleImageHasPositioner"]
+    ] = relationship("BLSampleImageHasPositioner", back_populates="Positioner_")
     BLSample_has_Positioner: Mapped[List["BLSampleHasPositioner"]] = relationship(
         "BLSampleHasPositioner", back_populates="Positioner_"
     )
@@ -2089,10 +2089,10 @@ class ScreeningStrategyWedge(Base):
         Double(asdecimal=True)
     )
 
-    ScreeningStrategySubWedge_: Mapped[List["ScreeningStrategySubWedge"]] = (
-        relationship(
-            "ScreeningStrategySubWedge", back_populates="ScreeningStrategyWedge"
-        )
+    ScreeningStrategySubWedge_: Mapped[
+        List["ScreeningStrategySubWedge"]
+    ] = relationship(
+        "ScreeningStrategySubWedge", back_populates="ScreeningStrategyWedge"
     )
     ScreeningStrategy_: Mapped["ScreeningStrategy"] = relationship(
         "ScreeningStrategy", back_populates="ScreeningStrategyWedge"
@@ -2441,16 +2441,16 @@ class BLSampleImageAutoScoreClass(Base):
     )
     blSampleImageAutoScoreSchemaId: Mapped[Optional[int]] = mapped_column(TINYINT)
 
-    BLSampleImageAutoScoreSchema_: Mapped["BLSampleImageAutoScoreSchema"] = (
-        relationship(
-            "BLSampleImageAutoScoreSchema", back_populates="BLSampleImageAutoScoreClass"
-        )
+    BLSampleImageAutoScoreSchema_: Mapped[
+        "BLSampleImageAutoScoreSchema"
+    ] = relationship(
+        "BLSampleImageAutoScoreSchema", back_populates="BLSampleImageAutoScoreClass"
     )
-    BLSampleImage_has_AutoScoreClass: Mapped[List["BLSampleImageHasAutoScoreClass"]] = (
-        relationship(
-            "BLSampleImageHasAutoScoreClass",
-            back_populates="BLSampleImageAutoScoreClass_",
-        )
+    BLSampleImage_has_AutoScoreClass: Mapped[
+        List["BLSampleImageHasAutoScoreClass"]
+    ] = relationship(
+        "BLSampleImageHasAutoScoreClass",
+        back_populates="BLSampleImageAutoScoreClass_",
     )
 
 
@@ -2991,9 +2991,9 @@ class PDBEntry(Base):
     AutoProcProgram_: Mapped["AutoProcProgram"] = relationship(
         "AutoProcProgram", back_populates="PDBEntry"
     )
-    PDBEntry_has_AutoProcProgram: Mapped[List["PDBEntryHasAutoProcProgram"]] = (
-        relationship("PDBEntryHasAutoProcProgram", back_populates="PDBEntry_")
-    )
+    PDBEntry_has_AutoProcProgram: Mapped[
+        List["PDBEntryHasAutoProcProgram"]
+    ] = relationship("PDBEntryHasAutoProcProgram", back_populates="PDBEntry_")
 
 
 class Person(Base):
@@ -3048,9 +3048,9 @@ class Person(Base):
     Proposal: Mapped[List["Proposal"]] = relationship(
         "Proposal", back_populates="Person_"
     )
-    ContainerRegistry_has_Proposal: Mapped[List["ContainerRegistryHasProposal"]] = (
-        relationship("ContainerRegistryHasProposal", back_populates="Person_")
-    )
+    ContainerRegistry_has_Proposal: Mapped[
+        List["ContainerRegistryHasProposal"]
+    ] = relationship("ContainerRegistryHasProposal", back_populates="Person_")
     LabContact: Mapped[List["LabContact"]] = relationship(
         "LabContact", back_populates="Person_"
     )
@@ -4549,9 +4549,9 @@ class Proposal(Base):
     Component: Mapped[List["Component"]] = relationship(
         "Component", back_populates="Proposal_"
     )
-    ContainerRegistry_has_Proposal: Mapped[List["ContainerRegistryHasProposal"]] = (
-        relationship("ContainerRegistryHasProposal", back_populates="Proposal_")
-    )
+    ContainerRegistry_has_Proposal: Mapped[
+        List["ContainerRegistryHasProposal"]
+    ] = relationship("ContainerRegistryHasProposal", back_populates="Proposal_")
     DiffractionPlan: Mapped[List["DiffractionPlan"]] = relationship(
         "DiffractionPlan", back_populates="Proposal_"
     )
@@ -5243,15 +5243,15 @@ class DiffractionPlan(Base):
     PurificationColumn_: Mapped["PurificationColumn"] = relationship(
         "PurificationColumn", back_populates="DiffractionPlan"
     )
-    BLSample_has_DataCollectionPlan: Mapped[List["BLSampleHasDataCollectionPlan"]] = (
-        relationship("BLSampleHasDataCollectionPlan", back_populates="DiffractionPlan_")
-    )
+    BLSample_has_DataCollectionPlan: Mapped[
+        List["BLSampleHasDataCollectionPlan"]
+    ] = relationship("BLSampleHasDataCollectionPlan", back_populates="DiffractionPlan_")
     Crystal: Mapped[List["Crystal"]] = relationship(
         "Crystal", back_populates="DiffractionPlan_"
     )
-    DataCollectionPlan_has_Detector: Mapped[List["DataCollectionPlanHasDetector"]] = (
-        relationship("DataCollectionPlanHasDetector", back_populates="DiffractionPlan_")
-    )
+    DataCollectionPlan_has_Detector: Mapped[
+        List["DataCollectionPlanHasDetector"]
+    ] = relationship("DataCollectionPlanHasDetector", back_populates="DiffractionPlan_")
     ExperimentKindDetails: Mapped[List["ExperimentKindDetails"]] = relationship(
         "ExperimentKindDetails", back_populates="DiffractionPlan_"
     )
@@ -5421,9 +5421,9 @@ class ParticlePicker(Base):
     AutoProcProgram_: Mapped["AutoProcProgram"] = relationship(
         "AutoProcProgram", back_populates="ParticlePicker"
     )
-    ParticleClassificationGroup: Mapped[List["ParticleClassificationGroup"]] = (
-        relationship("ParticleClassificationGroup", back_populates="ParticlePicker_")
-    )
+    ParticleClassificationGroup: Mapped[
+        List["ParticleClassificationGroup"]
+    ] = relationship("ParticleClassificationGroup", back_populates="ParticlePicker_")
 
 
 class PhasingStatistics(Base):
@@ -6900,9 +6900,9 @@ class Shipping(Base):
     dateOfShippingToUser: Mapped[Optional[datetime.datetime]] = mapped_column(DateTime)
     shippingType: Mapped[Optional[str]] = mapped_column(String(45))
     SAFETYLEVEL: Mapped[Optional[str]] = mapped_column(String(8))
-    deliveryAgent_flightCodeTimestamp: Mapped[Optional[datetime.datetime]] = (
-        mapped_column(TIMESTAMP, comment="Date flight code created, if automatic")
-    )
+    deliveryAgent_flightCodeTimestamp: Mapped[
+        Optional[datetime.datetime]
+    ] = mapped_column(TIMESTAMP, comment="Date flight code created, if automatic")
     deliveryAgent_label: Mapped[Optional[str]] = mapped_column(
         Text, comment="Base64 encoded pdf of airway label"
     )
@@ -6915,9 +6915,9 @@ class Shipping(Base):
     physicalLocation: Mapped[Optional[str]] = mapped_column(
         String(50), comment="Where shipment can be picked up from: i.e. Stores"
     )
-    deliveryAgent_pickupConfirmationTimestamp: Mapped[Optional[datetime.datetime]] = (
-        mapped_column(TIMESTAMP, comment="Date picked confirmed")
-    )
+    deliveryAgent_pickupConfirmationTimestamp: Mapped[
+        Optional[datetime.datetime]
+    ] = mapped_column(TIMESTAMP, comment="Date picked confirmed")
     deliveryAgent_pickupConfirmation: Mapped[Optional[str]] = mapped_column(
         String(10), comment="Confirmation number of requested pickup"
     )

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -6,7 +6,7 @@ from lims_utils.settings import Settings
 
 
 @pytest.mark.asyncio
-@patch("lims_utils.config.json.loads")
+@patch("lims_utils.settings.json.loads")
 async def test_return_default(mock_json_loads):
     """Should return default values"""
     mock_json_loads.return_value = {"auth": {}, "db": {}}
@@ -17,7 +17,7 @@ async def test_return_default(mock_json_loads):
 
 
 @pytest.mark.asyncio
-@patch("lims_utils.config.json.loads")
+@patch("lims_utils.settings.json.loads")
 async def test_custom(mock_json_loads):
     """Should return custom values"""
     mock_json_loads.return_value = {

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -5,8 +5,13 @@ import pytest
 from lims_utils.settings import Settings
 
 
+def new_read_all(_, _1):
+    return ""
+
+
 @pytest.mark.asyncio
 @patch("lims_utils.settings.json.loads")
+@patch("lims_utils.settings.Path.read_text", new=new_read_all)
 async def test_return_default(mock_json_loads):
     """Should return default values"""
     mock_json_loads.return_value = {"auth": {}, "db": {}}
@@ -18,6 +23,7 @@ async def test_return_default(mock_json_loads):
 
 @pytest.mark.asyncio
 @patch("lims_utils.settings.json.loads")
+@patch("lims_utils.settings.Path.read_text", new=new_read_all)
 async def test_custom(mock_json_loads):
     """Should return custom values"""
     mock_json_loads.return_value = {

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -1,0 +1,32 @@
+from unittest.mock import patch
+
+import pytest
+
+from lims_utils.settings import Settings
+
+
+@pytest.mark.asyncio
+@patch("lims_utils.config.json.loads")
+async def test_return_default(mock_json_loads):
+    """Should return default values"""
+    mock_json_loads.return_value = {"auth": {}, "db": {}}
+
+    settings = Settings()
+
+    assert settings.auth.endpoint == "https://localhost/auth"
+
+
+@pytest.mark.asyncio
+@patch("lims_utils.config.json.loads")
+async def test_custom(mock_json_loads):
+    """Should return custom values"""
+    mock_json_loads.return_value = {
+        "auth": {"endpoint": "https://localhost/diff-auth"},
+        "db": {"pool": 90},
+    }
+
+    settings = Settings()
+
+    assert settings.auth.endpoint == "https://localhost/diff-auth"
+
+    assert settings.db.pool == 90

--- a/tests/database/test_fast_count.py
+++ b/tests/database/test_fast_count.py
@@ -1,0 +1,30 @@
+from unittest.mock import patch
+
+from sqlalchemy import func, select
+from tests.mocks import FakeSession, query_eq
+
+from lims_utils.database import Database, get_session
+from lims_utils.tables import Proposal
+
+query = (
+    select(Proposal).filter(Proposal.proposalId == 1).order_by(Proposal.proposalNumber)
+)
+
+
+db = Database()
+fs = FakeSession()
+
+
+@patch.object(fs, "execute")
+def test_count(mock_session):
+    """Should count by removing order and getting first literal column"""
+
+    mock_session.return_value.scalar_one.return_value = 1
+    with get_session(lambda: fs):
+        response = db.fast_count(query)
+        assert response == 1
+
+    assert query_eq(
+        mock_session.call_args.args[0],
+        select(func.count(1)).select_from(Proposal).filter(Proposal.proposalId == 1),
+    )

--- a/tests/database/test_fast_count.py
+++ b/tests/database/test_fast_count.py
@@ -4,7 +4,7 @@ from sqlalchemy import func, select
 from tests.mocks import FakeSession, query_eq
 
 from lims_utils.database import Database, get_session
-from lims_utils.tables import Proposal
+from lims_utils.tables import Proposal  # type: ignore
 
 query = (
     select(Proposal).filter(Proposal.proposalId == 1).order_by(Proposal.proposalNumber)

--- a/tests/database/test_paginate.py
+++ b/tests/database/test_paginate.py
@@ -1,6 +1,6 @@
 from unittest.mock import patch
 
-from sqlalchemy import Select, select
+from sqlalchemy import select
 from tests.mocks import FakeSession, query_eq
 
 from lims_utils.database import Database, get_session

--- a/tests/database/test_paginate.py
+++ b/tests/database/test_paginate.py
@@ -1,0 +1,76 @@
+from unittest.mock import patch
+
+from sqlalchemy import Select, select
+from tests.mocks import FakeSession
+
+from lims_utils.database import Database, get_session
+from lims_utils.tables import Proposal
+
+query = select(Proposal).filter(Proposal.proposalId == 1)
+
+
+def query_eq(q1: Select, q2: Select):
+    return str(q1.compile(compile_kwargs={"literal_binds": True})) == str(
+        q2.compile(compile_kwargs={"literal_binds": True})
+    )
+
+
+db = Database()
+fs = FakeSession()
+
+
+@patch.object(fs, "execute")
+def test_paginate(mock_session):
+    """Should append limits/offset to original query"""
+
+    mock_session.return_value.all.return_value = ["a", "b", "c"]
+    with get_session(lambda: fs):
+        response = db.paginate(query, 20, 1)
+        assert response.items == ["a", "b", "c"]
+
+    assert query_eq(mock_session.call_args.args[0], query.limit(20).offset(20))
+
+
+@patch.object(fs, "scalars")
+def test_paginate_scalar(mock_session):
+    """Should append limits/offset to original query (in scalar form)"""
+
+    mock_session.return_value.all.return_value = ["f", "g", "h"]
+    with get_session(lambda: fs):
+        response = db.paginate(query, 20, 1, scalar=False, precounted_total=3)
+        assert response.items == ["f", "g", "h"]
+
+    assert query_eq(mock_session.call_args.args[0], query.limit(20).offset(20))
+
+
+@patch.object(fs, "execute")
+def test_paginate_reverse(mock_session):
+    """Should set page counting from last page if passed page is negative"""
+
+    mock_session.return_value.all.return_value = []
+    with get_session(lambda: fs):
+        response = db.paginate(query, 20, -1, precounted_total=100)
+        assert response.page == 4
+
+    assert query_eq(mock_session.call_args.args[0], query.limit(20).offset(80))
+
+
+def test_total_zero():
+    """Should return empty list if total is 0"""
+
+    query = select(Proposal).filter(Proposal.proposalId == 1)
+
+    with get_session(lambda: fs):
+        response = db.paginate(query, 20, -1, precounted_total=0)
+        assert response.items == []
+
+
+@patch.object(db, "fast_count")
+def test_fast_count(mock_fast_count):
+    """Should return count from fast_count method if fast counting is enabled"""
+
+    mock_fast_count.return_value = 150
+    with get_session(lambda: fs):
+        response = db.paginate(query, 20, -1, slow_count=False)
+        assert response.items == ["a", "b", "c"]
+        assert response.total == 150

--- a/tests/database/test_paginate.py
+++ b/tests/database/test_paginate.py
@@ -4,7 +4,7 @@ from sqlalchemy import Select, select
 from tests.mocks import FakeSession
 
 from lims_utils.database import Database, get_session
-from lims_utils.tables import Proposal
+from lims_utils.tables import Proposal  # type: ignore
 
 query = select(Proposal).filter(Proposal.proposalId == 1)
 

--- a/tests/database/test_paginate.py
+++ b/tests/database/test_paginate.py
@@ -1,18 +1,12 @@
 from unittest.mock import patch
 
 from sqlalchemy import Select, select
-from tests.mocks import FakeSession
+from tests.mocks import FakeSession, query_eq
 
 from lims_utils.database import Database, get_session
 from lims_utils.tables import Proposal  # type: ignore
 
 query = select(Proposal).filter(Proposal.proposalId == 1)
-
-
-def query_eq(q1: Select, q2: Select):
-    return str(q1.compile(compile_kwargs={"literal_binds": True})) == str(
-        q2.compile(compile_kwargs={"literal_binds": True})
-    )
 
 
 db = Database()

--- a/tests/database/test_session.py
+++ b/tests/database/test_session.py
@@ -1,46 +1,36 @@
 from unittest.mock import patch
 
 import pytest
+from tests.mocks import FakeSession
 
 from lims_utils.database import Database, get_session
 
-
-class FakeSession:
-    def close(self):
-        pass
-
-    def rollback(self):
-        pass
+db = Database()
+fs = FakeSession()
 
 
 def test_no_session():
     """Should raise exception if there is no session present"""
-    db = Database()
     with pytest.raises(Exception):
         db.session
 
 
-def test_session():
+@patch.object(fs, "close")
+def test_session(mock_session):
     """Should not raise exception if there is a session present in the context"""
-    db = Database()
-    fs = FakeSession()
 
-    with patch.object(fs, "close") as mock_session:
+    with get_session(lambda: fs):
+        db.session
+
+    assert mock_session.called
+
+
+@patch.object(fs, "rollback")
+def test_rollback(mock_session):
+    """Should rollback if unhandled exception occurs whilst in session context"""
+    with pytest.raises(Exception):
         with get_session(lambda: fs):
             db.session
+            raise Exception
 
-        assert mock_session.called
-
-
-def test_rollback():
-    """Should rollback if unhandled exception occurs whilst in session context"""
-    db = Database()
-    fs = FakeSession()
-
-    with patch.object(fs, "rollback") as mock_session:
-        with pytest.raises(Exception):
-            with get_session(lambda: fs):
-                db.session
-                raise Exception
-
-        assert mock_session.called
+    assert mock_session.called

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -1,0 +1,29 @@
+from sqlalchemy import Select
+
+
+class FakeExecute:
+    def all(self):
+        return ["a", "b", "c"]
+
+    def scalar_one(self):
+        return 1
+
+
+class FakeSession:
+    def close(self):
+        pass
+
+    def rollback(self):
+        pass
+
+    def execute(self, *args, **kwargs):
+        return FakeExecute()
+
+    def scalars(self, *args, **kwargs):
+        return FakeExecute()
+
+
+def query_eq(q1: Select, q2: Select):
+    return str(q1.compile(compile_kwargs={"literal_binds": True})) == str(
+        q2.compile(compile_kwargs={"literal_binds": True})
+    )

--- a/tests/models/test_proposal_reference.py
+++ b/tests/models/test_proposal_reference.py
@@ -1,0 +1,39 @@
+import pytest
+from pydantic import ValidationError
+
+from lims_utils.models import parse_proposal
+
+
+def test_proposal_reference():
+    """Should create proposal reference"""
+    proposal_reference = parse_proposal("cm123")
+
+    assert proposal_reference.code == "cm"
+    assert proposal_reference.number == 123
+
+
+def test_proposal_reference_visit_number():
+    """Should create proposal reference with visit number"""
+    proposal_reference = parse_proposal("cm123", 1)
+
+    assert proposal_reference.code == "cm"
+    assert proposal_reference.number == 123
+    assert proposal_reference.visit_number == 1
+
+
+def test_proposal_reference_code_not_alpha():
+    """Should raise error if code contains numeric characters"""
+    with pytest.raises(ValidationError):
+        parse_proposal("c0123")
+
+
+def test_proposal_reference_number_not_digit():
+    """Should raise error if number contains non-numeric characters"""
+    with pytest.raises(ValidationError):
+        parse_proposal("c01a3", 1)
+
+
+def test_proposal_reference_too_short():
+    """Should raise error if proposal reference is too short"""
+    with pytest.raises(ValueError):
+        parse_proposal("c", 1)

--- a/tests/settings/test_settings.py
+++ b/tests/settings/test_settings.py
@@ -1,12 +1,21 @@
 from unittest.mock import patch
 
 import pytest
+from pydantic import BaseModel
 
-from lims_utils.settings import Settings
+from lims_utils.settings import Auth, Settings
 
 
 def new_read_all(_, _1):
     return ""
+
+
+class Nested(BaseModel):
+    nested: Auth
+
+
+class ExpandedSettings(Settings):
+    nested: Nested
 
 
 @pytest.mark.asyncio
@@ -34,5 +43,23 @@ async def test_custom(mock_json_loads):
     settings = Settings()
 
     assert settings.auth.endpoint == "https://localhost/diff-auth"
+
+    assert settings.db.pool == 90
+
+
+@pytest.mark.asyncio
+@patch("lims_utils.settings.json.loads")
+@patch("lims_utils.settings.Path.read_text", new=new_read_all)
+async def test_nested(mock_json_loads):
+    """Should return custom values"""
+    mock_json_loads.return_value = {
+        "auth": {"endpoint": "https://localhost/diff-auth"},
+        "db": {"pool": 90},
+        "nested": {"nested": {"endpoint": "https://localhost/diff-auth"}},
+    }
+
+    settings = ExpandedSettings()
+
+    assert settings.nested.nested.endpoint == "https://localhost/diff-auth"
 
     assert settings.db.pool == 90

--- a/tests/settings/test_settings.py
+++ b/tests/settings/test_settings.py
@@ -51,7 +51,7 @@ async def test_custom(mock_json_loads):
 @patch("lims_utils.settings.json.loads")
 @patch("lims_utils.settings.Path.read_text", new=new_read_all)
 async def test_nested(mock_json_loads):
-    """Should return custom values"""
+    """Should return nested values"""
     mock_json_loads.return_value = {
         "auth": {"endpoint": "https://localhost/diff-auth"},
         "db": {"pool": 90},


### PR DESCRIPTION
### Added

- `ProposalReference` model and `parse_proposal`, for parsing proposal reference strings
- `Database()` now exposes `paginate`, for inserting pagination into queries, and `fast_count`, for counting total items rapidly
- `Settings()`, which provides a base settings model that reads from JSON files